### PR TITLE
Fixed encoding error caused by umaluts

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -20,8 +20,8 @@ Bitte verwende das <strong>Erstinstallationsimage</strong>, wenn sich auf deinem
 Originalfirmware befindet. Bei bereits installierter Freifunk/OpenWRT-Firmware verwende bitte
 die mit <strong>Upgrade</strong> bezeichnete Version.<br /><br />
 <small>
-<strong> Warnung für User von Ubiquiti Geräten mit AirOS Firmware Version höher 5.6.X:</strong><br />
-Das Flashen mit der Freifunkfirmware kann das Gerät unbenutzbar machen. Anleitung zum Downgrade gibt es <a href="https://wiki.darmstadt.freifunk.net/Ubiquiti_AirOS_5.6.x_mit_Gluon_Flashen" target="_blank">hier</a></small>
+<strong> Warnung f&uuml;r User von Ubiquiti Ger&auml;ten mit AirOS Firmware Version h&ouml;her 5.6.X:</strong><br />
+Das Flashen mit der Freifunkfirmware kann das Ger&auml;t unbenutzbar machen. Anleitung zum Downgrade gibt es <a href="https://wiki.darmstadt.freifunk.net/Ubiquiti_AirOS_5.6.x_mit_Gluon_Flashen" target="_blank">hier</a></small>
             </div>
         </div>
 


### PR DESCRIPTION
Fixed encoding error caused by umaluts in template.html. Replaced all ä with `&auml;`, all ü with `uuml;` and all ö with `ouml;`
This commit fixes Issue #5 and the following error message:
`UnicodeEncodeError: 'ascii' codec can't encode character '\xfc' in position 1110: ordinal not in range(128)`
